### PR TITLE
Update release-build Makefile recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,6 +334,6 @@ links: windows-x86-links windows-x64-links linux-x86-links linux-x64-links
 
 # Build everything for now until the quantity/size of binaries becomes
 # prohibitive.
-release-build: all links
+release-build: windows-x64 windows-x64-links
 
 	@echo "Completed all tasks for release build"


### PR DESCRIPTION
Build only Windows x64 binaries and populate the download links file with just those binaries.

Once support is added for other platforms this can be modified accordingly.