### PR TITLE
Temporarily disable problematic registry key

### DIFF
--- a/internal/restart/registry/assertions_windows.go
+++ b/internal/restart/registry/assertions_windows.go
@@ -87,20 +87,27 @@ func DefaultRebootRequiredAssertions() restart.RebootRequiredAsserters {
 				KeyExists: true,
 			},
 		},
-		Key{
-			root: registry.LOCAL_MACHINE,
+		/*
+			Temporarily disable until support for excluding specific paths is
+			added due to issues with specific subkey. Tests applied to systems
+			confirmed to have need of a reboot show that sufficient other
+			assertions are matched to reliably indicate the need for a reboot.
 
-			// When a reboot is needed there are subkeys. Observed subkeys
-			// have a GUID naming pattern.
-			path: `SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Services\Pending`,
-			evidence: KeyRebootEvidence{
-				SubKeysExist: true,
-			},
+			Key{
+				root: registry.LOCAL_MACHINE,
 
-			requirements: KeyAssertions{
-				KeyRequired: false,
+				// When a reboot is needed there are subkeys. Observed subkeys
+				// have a GUID naming pattern.
+				path: `SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Services\Pending`,
+				evidence: KeyRebootEvidence{
+					SubKeysExist: true,
+				},
+
+				requirements: KeyAssertions{
+					KeyRequired: false,
+				},
 			},
-		},
+		*/
 		Key{
 			root: registry.LOCAL_MACHINE,
 			path: `SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\PostRebootReporting`,


### PR DESCRIPTION
This key (under `HKLM\SOFTWARE`) contains subkeys whose presence is known to indicate the need for a reboot:

Microsoft\Windows\CurrentVersion\WindowsUpdate\Services\Pending

The `117cab2d-82b1-4b5a-a08c-4d62dbee7782` subkey, with value named `ClientApplicationID` and data of `Service Recovery`, has been found to continually be set on a Windows Server 2012 R2 instance for reasons unknown. The `Service Recovery` string suggests that the subkey is created to indicate that a service failed and either recovered or failed to do so.

Information on the specific subkey path is very thin however, only showing up in search results whether others report issues with a system continually showing the need for a reboot, but without a clear reason *why* the reboot is needed.

This seems to be the case here as well.

Until support is added to explicitly ignore the specific subkey, this commit temporarily disables the check for subkeys within the specified parent key path.

Testing has shown that sufficient assertions remain to reliably detect the need for a reboot; the impact from disabling this specific registry subkey assertion should be minimal.

fixes GH-38