### PR TITLE
Rename assertions performance data metrics

### DIFF
--- a/cmd/check_reboot/main.go
+++ b/cmd/check_reboot/main.go
@@ -162,19 +162,19 @@ func main() {
 		// The `time` (runtime) metric is appended at plugin exit, so do not
 		// duplicate it here.
 		{
-			Label: "all_assertions",
+			Label: "evaluated_assertions",
 			Value: fmt.Sprintf("%d", len(allAssertions)),
 		},
 		{
-			Label: "file_assertions",
+			Label: "evaluated_file_assertions",
 			Value: fmt.Sprintf("%d", len(fileAssertions)),
 		},
 		{
-			Label: "registry_assertions",
+			Label: "evaluated_registry_assertions",
 			Value: fmt.Sprintf("%d", len(registryAssertions)),
 		},
 		{
-			Label: "assertions_matched",
+			Label: "matched_assertions",
 			Value: fmt.Sprintf("%d", results.RebootAssertionsMatched()),
 		},
 		{


### PR DESCRIPTION
```
Old name                    New name
-----------------------------------------------------------
assertions_matched          matched_assertions
file_assertions             evaluated_file_assertions
registry_assertions         evaluated_registry_assertions
all_assertions              evaluated_assertions
```

fixes GH-37