### PR TITLE
Add support for ignoring specific paths

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,11 @@ type Config struct {
 	// the version string and then immediately exit the application.
 	ShowVersion bool
 
+	// ShowIgnored is a flag indicating whether the user opted to include
+	// assertion matches that are marked as ignored in the final plugin
+	// output.
+	ShowIgnored bool
+
 	// Log is an embedded zerolog Logger initialized via config.New().
 	Log zerolog.Logger
 }

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -20,6 +20,7 @@ const (
 	logLevelFlagHelp      string = "Sets log level."
 	brandingFlagHelp      string = "Toggles emission of branding details with plugin status details. This output is disabled by default."
 	verboseOutputFlagHelp string = "Toggles emission of detailed output. This level of output is disabled by default."
+	showIgnoredFlagHelp   string = "Toggles emission of ignored assertion matches in the final plugin output. This is disabled by default."
 )
 
 // Flag names for consistent references. Exported so that they're available
@@ -29,14 +30,16 @@ const (
 	// HelpFlagShort     string = "h"
 	// VersionFlagShort  string = "v"
 
-	VersionFlagLong   string = "version"
-	VerboseFlagLong   string = "verbose"
-	VerboseFlagShort  string = "v"
-	BrandingFlag      string = "branding"
-	TimeoutFlagLong   string = "timeout"
-	TimeoutFlagShort  string = "t"
-	LogLevelFlagLong  string = "log-level"
-	LogLevelFlagShort string = "ll"
+	VersionFlagLong      string = "version"
+	VerboseFlagLong      string = "verbose"
+	VerboseFlagShort     string = "v"
+	BrandingFlag         string = "branding"
+	TimeoutFlagLong      string = "timeout"
+	TimeoutFlagShort     string = "t"
+	ShowIgnoredFlagLong  string = "show-ignored"
+	ShowIgnoredFlagShort string = "li"
+	LogLevelFlagLong     string = "log-level"
+	LogLevelFlagShort    string = "ll"
 )
 
 // Default flag settings if not overridden by user input
@@ -44,6 +47,7 @@ const (
 	defaultLogLevel              string = "info"
 	defaultBranding              bool   = false
 	defaultVerboseOutput         bool   = false
+	defaultShowIgnored           bool   = false
 	defaultDisplayVersionAndExit bool   = false
 )
 

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -63,6 +63,9 @@ func (c *Config) handleFlagsConfig(appType AppType) {
 		flag.BoolVar(&c.VerboseOutput, VerboseFlagShort, defaultVerboseOutput, verboseOutputFlagHelp+" (shorthand)")
 		flag.BoolVar(&c.VerboseOutput, VerboseFlagLong, defaultVerboseOutput, verboseOutputFlagHelp)
 
+		flag.BoolVar(&c.ShowIgnored, ShowIgnoredFlagShort, defaultShowIgnored, showIgnoredFlagHelp+" (shorthand)")
+		flag.BoolVar(&c.ShowIgnored, ShowIgnoredFlagLong, defaultShowIgnored, showIgnoredFlagHelp)
+
 	case appType.Inspecter:
 
 		// Override the default Help output with a brief lead-in summary of

--- a/internal/restart/files/files.go
+++ b/internal/restart/files/files.go
@@ -8,9 +8,12 @@
 package files
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/atc0005/check-restart/internal/restart"
 )
@@ -23,6 +26,10 @@ var _ restart.RebootRequiredAsserter = (*File)(nil)
 // restart.FileRebootRequired implementation isn't correct.
 var _ FileRebootRequired = (*File)(nil)
 
+// Add "implements assertions" to fail the build if the restart.MatchedPath
+// implementation isn't correct.
+var _ restart.MatchedPath = (*MatchedPath)(nil)
+
 // FileRebootRequired represents the behavior of a file that can be evaluated
 // to indicate whether a reboot is required.
 //
@@ -34,6 +41,7 @@ type FileRebootRequired interface {
 	Path() string
 	Requirements() FileAssertions
 	String() string
+	// Err() error // TODO: Should this be an interface method?
 }
 
 // FileRebootEvidence indicates what file evidence is required in order to
@@ -59,12 +67,33 @@ type FileAssertions struct {
 	FileRequired bool
 }
 
+// FileRuntime is a collection of values for a File that are set during File
+// evaluation. Unlike the static values set for a File (e.g., path, any
+// requirements or assertions), these values are not known until execution or
+// runtime.
+type FileRuntime struct {
+	// err records any error that occurs while performing an evaluation.
+	err error
+
+	// evidenceFound is the collection of evidence found when evaluating a
+	// specified assertion.
+	evidenceFound FileRebootEvidence
+
+	// ignored indicates whether this value has been marked by filtering logic
+	// as not considered when determining whether a reboot is needed.
+	// ignored bool
+
+	// pathsMatched is a collection of file path values that were matched
+	// during evaluation of specified reboot required assertions.
+	pathsMatched MatchedPathIndex
+}
+
+// MatchedPathIndex is a collection of path values that were matched during
+// evaluation of specified reboot required assertions.
+type MatchedPathIndex map[string]MatchedPath
+
 // File represents a file that if found (and requirements met) indicates a
 // reboot is needed.
-//
-// TODO: At present, just finding the file is sufficient to indicate a reboot.
-// An enclosing type could be added to apply more specific requirements (e.g.,
-// such as finding a specific value on a specific line in a file).
 type File struct {
 	// path is either the fully-qualified path to a file or, if
 	// envVarPathPrefix is set is a partial path to be joined to
@@ -75,18 +104,48 @@ type File struct {
 	// fully-qualified path to a file.
 	envVarPathPrefix string
 
-	// evidence indicates what is required in order to determine that a reboot
-	// is needed.
-	// evidence FileRebootEvidence
+	// runtime is a collection of values that are set during evaluation.
+	// Unlike static values that are known ahead of time, these values are not
+	// known until execution or runtime.
+	runtime FileRuntime
+
+	// evidenceExpected indicates what evidence is used to determine that a
+	// reboot is needed.
+	evidenceExpected FileRebootEvidence
 
 	// requirements indicates what requirements must be met. If not met, this
 	// indicates that an error has occurred.
 	requirements FileAssertions
 }
 
+// Err exposes the underlying error (if any) as-is.
+func (f *File) Err() error {
+	return f.runtime.err
+}
+
+// MatchedPath represents a path that was matched when performing an
+// evaluation of a "reboot required" assertion.
+type MatchedPath struct {
+	// root is the left-most element of a matched path. This is the beginning
+	// of a qualified path.
+	root string
+
+	// relative is the unqualified path (without the root element). The base
+	// element of the path is usually included in this element.
+	relative string
+
+	// base is the last element or the right-most "leaf" value of a matched
+	// path.
+	base string
+
+	// ignored indicates whether this value has been marked by filtering logic
+	// as not considered when determining whether a reboot is needed.
+	ignored bool
+}
+
 // Validate performs basic validation. An error is returned for any validation
 // failures.
-func (f File) Validate() error {
+func (f *File) Validate() error {
 
 	if f.path == "" {
 		return fmt.Errorf(
@@ -99,8 +158,8 @@ func (f File) Validate() error {
 
 }
 
-// Path returns the specified path to the file.
-func (f File) Path() string {
+// Path returns the specified (potentially unqualified) path to the file.
+func (f *File) Path() string {
 	return f.path
 }
 
@@ -108,16 +167,16 @@ func (f File) Path() string {
 // of these requirements is not met than an error condition has been
 // encountered. Requirements does not indicate whether a reboot is needed,
 // only how potential "not found" conditions should be treated.
-func (f File) Requirements() FileAssertions {
+func (f *File) Requirements() FileAssertions {
 	return f.requirements
 }
 
-// String implements the Stringer interface and provides the fully qualified
-// path to a file. If the specified environment variable is found that value
-// is prepended to the given path value to form the fully qualified path to
-// the file. If an environment variable is not specified, the given path value
-// is expected to be fully qualified.
-func (f File) String() string {
+// String provides the fully qualified path for a File. If the specified
+// environment variable is found that value is prepended to the given path
+// value to form the fully qualified path to the file. If an environment
+// variable is not specified, the given path value is expected to be fully
+// qualified.
+func (f *File) String() string {
 
 	var pathPrefix string
 	if f.envVarPathPrefix != "" {
@@ -133,10 +192,93 @@ func (f File) String() string {
 
 }
 
+// AddMatchedPath records given paths as successful assertion matches.
+// Duplicate entries are ignored.
+func (f *File) AddMatchedPath(paths ...string) {
+
+	if f.runtime.pathsMatched == nil {
+		f.runtime.pathsMatched = make(MatchedPathIndex)
+	}
+
+	for _, path := range paths {
+		// Record MatchedPath if it does not already exist; we do not want to
+		// overwrite an existing entry in case any non-default metadata is set
+		// for the entry.
+		if _, ok := f.runtime.pathsMatched[path]; !ok {
+
+			// f.path may be unqualified. Unlike registry keys, these values are not
+			// intentionally split out into "root" keys and path values.
+
+			var rootPath string
+			qualifiedPath, err := filepath.Abs(f.String())
+			switch {
+			case err != nil:
+				rootPath = filepath.Dir(f.path)
+			default:
+				rootPath = filepath.Dir(qualifiedPath)
+			}
+
+			relPath, err := filepath.Rel(rootPath, path)
+			switch {
+			case err != nil:
+				logger.Printf("Failed to obtain relative path for %q using %q as the base", path, rootPath)
+				logger.Printf("Falling back to using %q as relative path", path)
+				relPath = path
+			default:
+				logger.Printf(
+					"Successfully resolved %q as relative path of %q using %q as root path",
+					relPath,
+					path,
+					rootPath,
+				)
+			}
+
+			matchedPath := MatchedPath{
+				root:     rootPath,
+				relative: relPath,
+				base:     filepath.Base(path),
+			}
+
+			f.runtime.pathsMatched[path] = matchedPath
+		}
+	}
+
+}
+
+// MatchedPaths returns all recorded paths from successful assertion matches.
+//
+//	func (f *File) MatchedPaths() []string {
+//		paths := make([]string, 0, len(f.runtime.pathsMatched))
+//		for path := range f.runtime.pathsMatched {
+//			paths = append(paths, path)
+//		}
+//		return paths
+//	}
+func (f *File) MatchedPaths() restart.MatchedPaths {
+
+	pathStrings := make([]string, 0, len(f.runtime.pathsMatched))
+	matchedPaths := make(restart.MatchedPaths, 0, len(f.runtime.pathsMatched))
+
+	// Pull all of the keys.
+	for k := range f.runtime.pathsMatched {
+		pathStrings = append(pathStrings, k)
+	}
+
+	// Sort them.
+	sort.Strings(sort.StringSlice(pathStrings))
+
+	// Use them to pull out the MatchedPath entries in order.
+	for _, path := range pathStrings {
+		logger.Printf("File.runtime.pathsMatched entry: %q", path)
+		matchedPaths = append(matchedPaths, f.runtime.pathsMatched[path])
+	}
+
+	return matchedPaths
+}
+
 // Evaluate applies the specified assertion to determine if a reboot is
 // necessary.
-func (f File) Evaluate() restart.RebootCheckResult {
-
+func (f *File) Evaluate() {
 	logger.Printf("Given file: %s", f)
 
 	filePath := filepath.Clean(f.String())
@@ -146,34 +288,363 @@ func (f File) Evaluate() restart.RebootCheckResult {
 	switch {
 	case os.IsNotExist(err):
 		logger.Printf("File %s not found, reboot not required due to this file.", filePath)
-		return restart.RebootCheckResult{
-			Examined:       f,
-			RebootRequired: false,
-		}
+		return
 
 	case err != nil:
-		return restart.RebootCheckResult{
-			Examined:       f,
-			RebootRequired: false,
-			Err: fmt.Errorf(
-				"unexpected error occurred while opening file %s: %w",
-				filePath,
-				err,
-			),
-		}
+		f.runtime.err = err
+
+		return
 
 	default:
 		logger.Printf("File %q found!", filePath)
 		logger.Println("Reboot Required!")
-		return restart.RebootCheckResult{
-			Examined:       f,
-			RebootRequired: true,
-			RebootReasons: []string{
-				fmt.Sprintf(
-					"File %s found", filePath,
-				),
-			},
-		}
+
+		f.SetFoundEvidenceFileExists()
+		f.AddMatchedPath(filePath)
+
+		return
 	}
 
 }
+
+// Filter uses the list of specified ignore patterns to mark each matched path
+// for the File as ignored *IF* a match is found. If no matched paths are
+// recorded Filter makes no changes. Filter should be called before performing
+// final state evaluation.
+func (f *File) Filter(ignorePatterns []string) {
+
+	numIgnorePatterns := len(ignorePatterns)
+	var numIgnorePatternsApplied int
+
+	if numIgnorePatterns == 0 {
+		logger.Printf("0 ignore patterns specified for %q; skipping Filter", f)
+		return
+	}
+
+	logger.Printf(
+		"%d ignore patterns specified for %q; applying Filter",
+		numIgnorePatterns,
+		f,
+	)
+
+	for pathString, matchedPath := range f.runtime.pathsMatched {
+		logger.Printf("Searching matched path %q for ignore pattern matches", pathString)
+
+		for _, ignorePattern := range ignorePatterns {
+			logger.Printf("case-insensitively performing substring match for %q", ignorePattern)
+
+			if strings.Contains(strings.ToLower(pathString), strings.ToLower(ignorePattern)) {
+				logger.Printf("matchedPath %q contains ignorePattern %q", pathString, ignorePattern)
+				logger.Printf("marking matched path %q as ignored", pathString)
+
+				matchedPath.ignored = true
+				f.runtime.pathsMatched[pathString] = matchedPath
+				numIgnorePatternsApplied++
+			}
+		}
+	}
+
+	logger.Printf("%d ignore patterns applied for %q", numIgnorePatternsApplied, f)
+
+}
+
+// ExpectedEvidence returns the specified evidence that (if found) indicates a
+// reboot is needed.
+func (f *File) ExpectedEvidence() FileRebootEvidence {
+	return f.evidenceExpected
+}
+
+// DiscoveredEvidence returns the discovered evidence from an earlier
+// evaluation.
+func (f *File) DiscoveredEvidence() FileRebootEvidence {
+	return f.runtime.evidenceFound
+}
+
+// SetFoundEvidenceFileExists records that the FileExists reboot evidence was
+// found.
+func (f *File) SetFoundEvidenceFileExists() {
+	logger.Printf("Recording that the FileExists evidence was found for %q", f)
+	f.runtime.evidenceFound.FileExists = true
+}
+
+// SetFoundEvidenceFileEmpty records that the FileEmpty reboot evidence was
+// found.
+func (f *File) SetFoundEvidenceFileEmpty() {
+	logger.Printf("Recording that the FileEmpty evidence was found for %q", f)
+	f.runtime.evidenceFound.FileEmpty = true
+}
+
+// SetFoundEvidenceFileNotEmpty records that the FileNotEmpty reboot evidence
+// was found.
+func (f *File) SetFoundEvidenceFileNotEmpty() {
+	logger.Printf("Recording that the FileNotEmpty evidence was found for %q", f)
+	f.runtime.evidenceFound.FileNotEmpty = true
+}
+
+// SetFoundEvidenceFileExecutable records that the FileExecutable reboot evidence
+// was found.
+func (f *File) SetFoundEvidenceFileExecutable() {
+	logger.Printf("Recording that the FileExecutable evidence was found for %q", f)
+	f.runtime.evidenceFound.FileExecutable = true
+}
+
+// SetFoundEvidenceFileIsSymlink records that the FileIsSymlink reboot evidence
+// was found.
+func (f *File) SetFoundEvidenceFileIsSymlink() {
+	logger.Printf("Recording that the FileIsSymlink evidence was found for %q", f)
+	f.runtime.evidenceFound.FileIsSymlink = true
+}
+
+// HasEvidence indicates whether any evidence was found for an assertion
+// evaluation.
+func (f *File) HasEvidence() bool {
+	if f.runtime.evidenceFound.FileExists {
+		return true
+	}
+	if f.runtime.evidenceFound.FileEmpty {
+		return true
+	}
+	if f.runtime.evidenceFound.FileNotEmpty {
+		return true
+	}
+	if f.runtime.evidenceFound.FileExecutable {
+		return true
+	}
+	if f.runtime.evidenceFound.FileIsSymlink {
+		return true
+	}
+
+	return false
+}
+
+// Ignored indicates whether the File has been marked as ignored.
+func (f *File) Ignored() bool {
+
+	numMatchedPaths := len(f.runtime.pathsMatched)
+
+	// logger.Printf("%d pathsMatched entries for %q", numMatchedPaths, k)
+
+	// An empty collection of entries can occur if an error occurred or if no
+	// assertions were matched.
+	if numMatchedPaths == 0 {
+		// logger.Printf("%d pathsMatched entries for %q", numMatchedPaths, f)
+		return false
+	}
+
+	for _, v := range f.runtime.pathsMatched {
+		if !v.ignored {
+			return false
+		}
+
+		logger.Printf("%s is marked as ignored\n", v)
+	}
+
+	// The entire File is ignored *only* if all recorded match path entries
+	// are marked as ignored.
+	return true
+}
+
+// HasIgnored indicates whether any matched path for the File have been marked
+// as ignored.
+func (f *File) HasIgnored() bool {
+	for _, v := range f.runtime.pathsMatched {
+		if v.ignored {
+			return true
+		}
+	}
+
+	return false
+}
+
+// RebootRequired indicates whether an evaluation determined that a reboot is
+// needed. If the File has been marked as ignored (all recorded matched paths
+// marked as ignored) the need for a reboot is not indicated.
+func (f *File) RebootRequired() bool {
+	if !f.Ignored() && f.HasEvidence() {
+		return true
+	}
+
+	return false
+}
+
+// IsCriticalState indicates whether an evaluation determined that the File is
+// in a CRITICAL state. Whether the File has been marked as Ignored is
+// considered. The caller is responsible for filtering the collection prior to
+// calling this method.
+func (f *File) IsCriticalState() bool {
+	switch {
+
+	// If we could determine that a reboot is required we consider that to be
+	// a WARNING state.
+	case !f.Ignored() && f.RebootRequired():
+		return false
+
+	// If we were unable to determine whether a reboot is required due to
+	// errors we consider that to be a CRITICAL state.
+	case !f.Ignored() && f.Err() != nil:
+		if errors.Is(f.Err(), restart.ErrMissingOptionalItem) {
+			return false
+		}
+		return true
+
+	// No reboot required and no errors, not CRITICAL state.
+	default:
+		return false
+
+	}
+}
+
+// IsWarningState indicates whether an evaluation determined that the File is
+// in a WARNING state. Whether the File has been marked as Ignored is
+// considered. The caller is responsible for filtering the collection prior to
+// calling this method.
+func (f *File) IsWarningState() bool {
+	return !f.Ignored() && f.RebootRequired()
+}
+
+// IsOKState indicates whether an evaluation determined that the File is in an
+// OK state. Whether the File has been marked as Ignored is considered. The
+// caller is responsible for filtering the collection prior to calling this
+// method.
+//
+// TODO: Cleanup the logic.
+func (f *File) IsOKState() bool {
+	switch {
+	case f.Ignored():
+		return true
+	case !f.Ignored() && f.RebootRequired():
+		return false
+	case !f.Ignored() && f.Err() != nil:
+		if errors.Is(f.Err(), restart.ErrMissingOptionalItem) {
+			return true
+		}
+		return false
+	default:
+		return true
+	}
+}
+
+// RebootReasons returns a list of the reasons associated with the evidence
+// found for an evaluation that indicates a reboot is needed.
+func (f *File) RebootReasons() []string {
+	// The usual scenario is one reason per evidence match.
+	reasons := make([]string, 0, 1)
+
+	if f.runtime.evidenceFound.FileExists {
+		reasons = append(reasons, fmt.Sprintf(
+			"File %s found", f,
+		))
+	}
+
+	if f.runtime.evidenceFound.FileEmpty {
+		reasons = append(reasons, fmt.Sprintf(
+			"File %s empty (but should not be)", f,
+		))
+	}
+
+	if f.runtime.evidenceFound.FileNotEmpty {
+		reasons = append(reasons, fmt.Sprintf(
+			"File %s not empty (but expected to be)", f,
+		))
+	}
+
+	if f.runtime.evidenceFound.FileExecutable {
+		reasons = append(reasons, fmt.Sprintf(
+			"File %s executable (but should not be)", f,
+		))
+	}
+
+	if f.runtime.evidenceFound.FileIsSymlink {
+		reasons = append(reasons, fmt.Sprintf(
+			"File %s is a symbolic link (but should not be)", f,
+		))
+	}
+
+	return reasons
+}
+
+// Root returns the left-most element of a matched path. This returned value
+// is the beginning of a qualified path.
+func (mp MatchedPath) Root() string {
+	return mp.root
+}
+
+// Rel returns the relative (unqualified) element of a matched path. The base
+// element of the path isi usually included in this element.
+func (mp MatchedPath) Rel() string {
+	return mp.relative
+}
+
+// Base returns the last or right-most "leaf" element of a matched path.
+func (mp MatchedPath) Base() string {
+	return mp.base
+}
+
+// Full returns the qualified matched path value.
+func (mp MatchedPath) Full() string {
+	return filepath.Join(mp.root, mp.relative)
+}
+
+// String provides a human readable version of the matched path value.
+func (mp MatchedPath) String() string {
+	return mp.Full()
+}
+
+// func matchedPathsFromPathStrings(rootPath string, pathStrings []string) restart.MatchedPaths {
+//
+// 	matchedPaths := make(restart.MatchedPaths, 0, len(pathStrings))
+//
+// 	for _, path := range pathStrings {
+// 		relPath, err := filepath.Rel(rootPath, path)
+// 		switch {
+// 		case err != nil:
+// 			logger.Printf("Failed to obtain relative path for %q using %q as the base", path, rootPath)
+// 			logger.Printf("Falling back to using %q as relative path", path)
+// 			relPath = path
+// 		default:
+// 			logger.Printf(
+// 				"Successfully resolved %q as relative path of %q using %q as root path",
+// 				relPath,
+// 				path,
+// 				rootPath,
+// 			)
+// 		}
+//
+// 		matchedPath := MatchedPath{
+// 			root:     rootPath,
+// 			relative: relPath,
+// 			base:     filepath.Base(path),
+// 		}
+//
+// 		matchedPaths = append(matchedPaths, matchedPath)
+// 	}
+//
+// 	return matchedPaths
+//
+// }
+//
+// func matchedPathFromPathString(rootPath string, pathString string) restart.MatchedPath {
+//
+// 	relPath, err := filepath.Rel(rootPath, pathString)
+// 	switch {
+// 	case err != nil:
+// 		logger.Printf("Failed to obtain relative path for %q using %q as the base", pathString, rootPath)
+// 		logger.Printf("Falling back to using %q as relative path", pathString)
+// 		relPath = pathString
+// 	default:
+// 		logger.Printf(
+// 			"Successfully resolved %q as relative path of %q using %q as root path",
+// 			relPath,
+// 			pathString,
+// 			rootPath,
+// 		)
+// 	}
+//
+// 	matchedPath := MatchedPath{
+// 		root:     rootPath,
+// 		relative: relPath,
+// 		base:     filepath.Base(pathString),
+// 	}
+//
+// 	return matchedPath
+// }

--- a/internal/restart/files/files_unix.go
+++ b/internal/restart/files/files_unix.go
@@ -14,6 +14,12 @@ import (
 	"github.com/atc0005/check-restart/internal/restart"
 )
 
+// DefaultRebootRequiredIgnoredPaths provides the default collection of paths
+// for registry related reboot required assertions that should be ignored.
+func DefaultRebootRequiredIgnoredPaths() []string {
+	return []string{}
+}
+
 // DefaultRebootRequiredAssertions provides the default collection of file
 // related reboot required assertions.
 func DefaultRebootRequiredAssertions() restart.RebootRequiredAsserters {

--- a/internal/restart/files/files_windows.go
+++ b/internal/restart/files/files_windows.go
@@ -14,6 +14,12 @@ import (
 	"github.com/atc0005/check-restart/internal/restart"
 )
 
+// DefaultRebootRequiredIgnoredPaths provides the default collection of paths
+// for registry related reboot required assertions that should be ignored.
+func DefaultRebootRequiredIgnoredPaths() []string {
+	return []string{}
+}
+
 // DefaultRebootRequiredAssertions provides the default collection of file
 // related reboot required assertions.
 func DefaultRebootRequiredAssertions() restart.RebootRequiredAsserters {
@@ -21,7 +27,7 @@ func DefaultRebootRequiredAssertions() restart.RebootRequiredAsserters {
 	var assertions = restart.RebootRequiredAsserters{
 
 		// Test entry.
-		// File{
+		// &File{
 		// 	// path: `C:\Windows\notepad.exe`,
 		// 	envVarPathPrefix: "SystemRoot",
 		// 	path:             `notepad.exe`,
@@ -29,7 +35,7 @@ func DefaultRebootRequiredAssertions() restart.RebootRequiredAsserters {
 
 		// Found on Windows desktop and server variants after applying Windows
 		// Updates.
-		File{
+		&File{
 			// path: `C:\Windows\WinSxS\pending.xml`,
 			envVarPathPrefix: "SystemRoot",
 			path:             `WinSxS\pending.xml`,

--- a/internal/restart/registry/assertions_unix.go
+++ b/internal/restart/registry/assertions_unix.go
@@ -16,6 +16,14 @@ import (
 	"github.com/atc0005/check-restart/internal/restart"
 )
 
+// DefaultRebootRequiredIgnoredPaths provides the default collection of paths
+// for registry related reboot required assertions that should be ignored.
+func DefaultRebootRequiredIgnoredPaths() []string {
+
+	logger.Println("WARNING: This tool is not supported for non-Windows systems!")
+	return []string{}
+}
+
 // DefaultRebootRequiredAssertions provides the default collection of registry
 // related reboot required assertions.
 func DefaultRebootRequiredAssertions() restart.RebootRequiredAsserters {

--- a/internal/restart/reports/reports.go
+++ b/internal/restart/reports/reports.go
@@ -9,6 +9,7 @@ package reports
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/atc0005/check-restart/internal/restart"
@@ -16,8 +17,10 @@ import (
 )
 
 // CheckRebootOneLineSummary returns a one-line summary of the evaluation
-// results suitable for display and notification purposes.
-func CheckRebootOneLineSummary(rcr restart.RebootCheckResults) string {
+// results suitable for display and notification purposes. A boolean value is
+// accepted which indicates whether assertion values marked as ignored (during
+// filtering) should also be considered.
+func CheckRebootOneLineSummary(assertions restart.RebootRequiredAsserters, evalIgnored bool) string {
 	var summary string
 
 	switch {
@@ -25,31 +28,39 @@ func CheckRebootOneLineSummary(rcr restart.RebootCheckResults) string {
 	// We're not checking whether errors were encountered at this point, just
 	// whether a successful determination has been made that a reboot is
 	// needed.
-	case rcr.RebootRequired():
+	case assertions.RebootRequired():
 		summary = fmt.Sprintf(
-			"%s: Reboot needed (applied %d reboot assertions, %d matched)",
-			rcr.ServiceState().Label,
-			rcr.RebootAssertionsApplied(),
-			rcr.RebootAssertionsMatched(),
+			"%s: Reboot needed (assertions: %d applied, %d matched, %d ignored)",
+			assertions.ServiceState().Label,
+			assertions.NumApplied(),
+			assertions.NumMatched(),
+			assertions.NumIgnored(),
 		)
 
 	// Errors have occurred which prevent accurately detecting whether a
 	// reboot is needed.
-	case rcr.HasErrors():
+	case assertions.HasErrors(evalIgnored):
 		summary = fmt.Sprintf(
-			"%s: Reboot evaluation failed due to errors (applied %d reboot assertions, %d errors occurred)",
-			rcr.ServiceState().Label,
-			rcr.RebootAssertionsApplied(),
-			rcr.NumErrors(),
+			// "%s: Reboot evaluation failed due to errors (applied %d reboot assertions, %d errors occurred)",
+			"%s: Reboot evaluation failed; %d errors (assertions: %d applied, %d matched, %d ignored)",
+			assertions.ServiceState().Label,
+			assertions.NumErrors(evalIgnored),
+			assertions.NumApplied(),
+			assertions.NumMatched(),
+			assertions.NumIgnored(),
 		)
 
-	case rcr.IsOKState():
+	case assertions.IsOKState():
 		summary = fmt.Sprintf(
-			"%s: Reboot not needed (applied %d reboot assertions, %d matched)",
-			rcr.ServiceState().Label,
-			rcr.RebootAssertionsApplied(),
-			rcr.RebootAssertionsMatched(),
+			"%s: Reboot not needed (assertions: %d applied, %d matched, %d ignored)",
+			assertions.ServiceState().Label,
+			assertions.NumApplied(),
+			assertions.NumMatched(),
+			assertions.NumIgnored(),
 		)
+
+	default:
+		summary = "BUG: Expected assertions collection state unexpected"
 
 	}
 
@@ -57,112 +68,162 @@ func CheckRebootOneLineSummary(rcr restart.RebootCheckResults) string {
 
 }
 
-// CheckRebootReport returns a formatted report of the evaluation results
-// suitable for display and notification purposes. If specified, additional
-// details are provided.
-func CheckRebootReport(rcr restart.RebootCheckResults, verbose bool) string {
-	var report strings.Builder
-
+func writeReportHeader(w io.Writer, assertions restart.RebootRequiredAsserters, verbose bool) {
 	fmt.Fprintf(
-		&report,
+		w,
 		"%[1]sSummary:%[1]s%[1]s",
 		nagios.CheckOutputEOL,
 	)
 
 	fmt.Fprintf(
-		&report,
+		w,
 		"  - %d total reboot assertions applied%s",
-		rcr.RebootAssertionsApplied(),
+		assertions.NumApplied(),
 		nagios.CheckOutputEOL,
 	)
 
 	fmt.Fprintf(
-		&report,
+		w,
 		"  - %d total reboot assertions matched%s",
-		rcr.RebootAssertionsMatched(),
+		assertions.NumMatched(),
 		nagios.CheckOutputEOL,
 	)
 
 	fmt.Fprintf(
-		&report,
+		w,
+		"  - %d total reboot assertions ignored%s",
+		assertions.NumIgnored(),
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		w,
 		"%[1]s%[2]s%[1]s%[1]s",
 		nagios.CheckOutputEOL,
 		strings.Repeat("-", 50),
 	)
+}
+
+func writeAssertions(w io.Writer, assertions restart.RebootRequiredAsserters, verbose bool) {
+
+	// Specific "template" strings used to control formatting/indentation
+	// levels for the first item in a listing and any "sub details" associated
+	// with the item. The formatting is intended to convey this relationship
+	// at a glance.
+	const topDetailTemplateStr = "\n  - %s%s"
+	const subDetailTemplateStr = "    %s%s"
+
+	for _, assertion := range assertions {
+
+		// if len(assertion.RebootReasons()) > 0 && assertion.RebootRequired() && !assertion.Ignored() {
+
+		// We don't filter on whether the assertion is ignored as we're using
+		// this helper function to process collections of both types.
+		if assertion.HasEvidence() {
+
+			for _, reason := range assertion.RebootReasons() {
+
+				fmt.Fprintf(
+					w,
+					topDetailTemplateStr,
+					reason,
+					nagios.CheckOutputEOL,
+				)
+
+				switch v := assertion.(type) {
+				case restart.RebootRequiredAsserterWithSubPaths:
+
+					if v.HasSubPathMatches() {
+						logger.Printf("%q has subkey evidence", assertion.String())
+
+						if verbose {
+							for _, path := range v.MatchedPaths() {
+								fmt.Fprintf(
+									w,
+									subDetailTemplateStr,
+									"subkey: "+path.Base(),
+									nagios.CheckOutputEOL,
+								)
+							}
+						}
+
+					}
+
+				default:
+
+					logger.Printf("%q does not have subkey evidence", assertion.String())
+				}
+
+				if verbose {
+					switch v := assertion.(type) {
+					case restart.RebootRequiredAsserterWithDataDisplay:
+						logger.Printf("Type assertion worked, value available for check result")
+
+						fmt.Fprintf(
+							w,
+							subDetailTemplateStr,
+							v.DataDisplay(),
+							nagios.CheckOutputEOL,
+						)
+
+					default:
+						logger.Printf("Type assertion failed, value not available for check result")
+						logger.Printf("Type found: %T", v)
+					}
+				}
+
+			}
+
+		}
+
+	}
+
+	fmt.Fprint(w, nagios.CheckOutputEOL)
+}
+
+// CheckRebootReport returns a formatted report of the evaluation results
+// suitable for display and notification purposes. If specified, additional
+// details are provided.
+func CheckRebootReport(assertions restart.RebootRequiredAsserters, showIgnored bool, verbose bool) string {
+	var report strings.Builder
+
+	writeReportHeader(&report, assertions, verbose)
 
 	switch {
 
-	case rcr.RebootRequired():
+	case assertions.RebootRequired():
+
+		// writeMatchedPaths(&report, assertions, verbose)
+
 		fmt.Fprintf(
 			&report,
-			"Reboot required because:%[1]s%[1]s",
+			"Reboot required because:%[1]s",
 			nagios.CheckOutputEOL,
 		)
 
-		for _, result := range rcr {
+		notIgnoredAssertions := assertions.NotIgnoredItems()
 
-			// TODO: Use panic here to surface the issue explicitly?
-			if len(result.RebootReasons) > 0 && !result.RebootRequired {
-				warningMessage := fmt.Sprintf(
-					"BUG: RebootReasons (%d) recorded for %q, but RebootRequired flag not set",
-					len(result.RebootReasons),
-					result.Examined,
-				)
-				logger.Print(warningMessage)
+		logger.Printf("%d notIgnoredAssertions to process", len(notIgnoredAssertions))
 
-				fmt.Fprint(
-					&report,
-					warningMessage,
-					nagios.CheckOutputEOL,
-				)
-			}
+		writeAssertions(&report, notIgnoredAssertions, verbose)
 
-			// If there is one or more reasons listed for why a reboot is
-			// required that should be enough to indicate that the need for a
-			// reboot was determined.
-			// if len(result.RebootReasons) > 0 {
-			//
-			// Even so, perhaps there is an advantage to being overly
-			// cautious?
-			if len(result.RebootReasons) > 0 && result.RebootRequired {
-
-				for _, reason := range result.RebootReasons {
-
-					fmt.Fprintf(
-						&report,
-						"\n%3s %s%s",
-						"-",
-						reason,
-						nagios.CheckOutputEOL,
-					)
-
-					if verbose {
-						switch v := result.Examined.(type) {
-						case restart.RebootRequiredAsserterWithDataDisplay:
-							logger.Printf("Type assertion worked, value available for check result")
-
-							fmt.Fprintf(
-								&report,
-								"    %s%s",
-								v.DataDisplay(),
-								nagios.CheckOutputEOL,
-							)
-
-						default:
-							logger.Printf("Type assertion failed, value not available for check result")
-							logger.Printf("Type found: %T", v)
-						}
-					}
-
-				}
-			}
-		}
-
-		fmt.Fprint(&report, nagios.CheckOutputEOL)
-
-	case rcr.IsOKState():
+	case assertions.IsOKState():
 		fmt.Fprintf(&report, "Reboot not required%s", nagios.CheckOutputEOL)
 
+	}
+
+	if assertions.HasIgnored() && showIgnored {
+		fmt.Fprintf(
+			&report,
+			"%[1]sAssertions ignored:%[1]s",
+			nagios.CheckOutputEOL,
+		)
+
+		ignoredAssertions := assertions.IgnoredItems()
+
+		logger.Printf("%d ignoredAssertions to process", len(ignoredAssertions))
+
+		writeAssertions(&report, ignoredAssertions, verbose)
 	}
 
 	return report.String()

--- a/internal/restart/restart.go
+++ b/internal/restart/restart.go
@@ -36,36 +36,6 @@ var ErrMissingRequiredItem = errors.New("missing required reboot asserter")
 // key, file) was not found, though it is not required to be present.
 var ErrMissingOptionalItem = errors.New("missing optional reboot asserter")
 
-// RebootCheckResult is returned from an individual evaluation and indicates
-// whether a reboot is required.
-type RebootCheckResult struct {
-
-	// Examined is the specific File or Key that was evaluated in order to
-	// provide this evaluation/check result.
-	//
-	// NOTE: In most cases the enclosing type and not the embedded type (e.g.,
-	// KeyInt instead of the embedded Key) should be recorded so that client
-	// code will have access to additional fields (e.g., for use in final
-	// report output).
-	Examined RebootRequiredAsserter
-
-	// Err records any error that occurs while performing an evaluation.
-	Err error
-
-	// RebootRequired provides the definitive decision regarding whether a
-	// reboot is needed. In case of an error we assume that no reboot is
-	// needed.
-	RebootRequired bool // TODO: Make this a pointer?
-
-	// RebootReasons is an optional human readable list of reasons why a
-	// reboot is required.
-	RebootReasons []string
-}
-
-// RebootCheckResults is a collection of "reboot required" evaluations and
-// indicates whether a reboot is required.
-type RebootCheckResults []RebootCheckResult
-
 // ServiceStater represents a type that is capable of evaluating its overall
 // state.
 type ServiceStater interface {
@@ -74,28 +44,67 @@ type ServiceStater interface {
 	IsOKState() bool
 }
 
-// RebootRequiredAsserter represents an item (reg key, file) that (if all
-// requirements are matched) indicates the need for a reboot.
-type RebootRequiredAsserter interface {
-	Validate() error
-	Evaluate() RebootCheckResult
+// MatchedPath represents a the path to an item (e.g., reg key, file) that was
+// successfully matched when evaluating an assertion.
+type MatchedPath interface {
+	Root() string
+	Rel() string
+	Base() string
+	Full() string
 	String() string
 }
 
+// RebootRequiredAsserter represents an item (reg key, file) that is able to
+// determine the need for a reboot.
+type RebootRequiredAsserter interface {
+
+	// Values implementing this interface are able to determine their service
+	// state.
+	ServiceStater
+
+	// Err does not apply filtering. This is left to higher-level code
+	// operating on values implementing this interface.
+	Err() error
+
+	Validate() error
+	Evaluate()
+	String() string
+	RebootReasons() []string
+	Ignored() bool
+	MatchedPaths() MatchedPaths
+	RebootRequired() bool
+	HasEvidence() bool
+	Filter(ignorePatterns []string)
+}
+
 // RebootRequiredAsserterWithDataDisplay represents an item (reg key, file)
-// that (if all requirements are matched) indicates the need for a reboot and
-// provides the value associated with the item for display purposes.
+// that is able to determine the need for a reboot and provide the value
+// associated with the item for display purposes.
 type RebootRequiredAsserterWithDataDisplay interface {
 	RebootRequiredAsserter
 
-	// DataDisplay provides a string representation of a registry key's actual
-	// data for display purposes.
+	// DataDisplay provides a string representation of an item's actual data
+	// for display purposes.
 	DataDisplay() string
+}
+
+// RebootRequiredAsserterWithSubPaths represents an item (reg key, file) that
+// is able to determine the need for a reboot and if there is evidence of
+// subpath matches.
+type RebootRequiredAsserterWithSubPaths interface {
+	RebootRequiredAsserter
+
+	// HasSubPathMatches indicates whether an item has evidence of subpath
+	// matches.
+	HasSubPathMatches() bool
 }
 
 // RebootRequiredAsserters is a collection of items that if (if all
 // requirements are matched) indicate the need for a reboot.
 type RebootRequiredAsserters []RebootRequiredAsserter
+
+// MatchedPaths is a collection of MatchedPath values.
+type MatchedPaths []MatchedPath
 
 // Validate performs basic validation of all items in the collection. An error
 // is returned for any validation failures.
@@ -103,27 +112,44 @@ func (rras RebootRequiredAsserters) Validate() error {
 	logger.Printf("%d assertions to validate", len(rras))
 
 	for _, rra := range rras {
-		logger.Printf("Validating %s", rra.String())
+		logger.Printf("Validating %q", rra.String())
 
 		if err := rra.Validate(); err != nil {
 			return err
 		}
+
+		logger.Printf("Successfully validated %q", rra.String())
 	}
 
 	return nil
 }
 
-// HasErrors indicates whether any of the evaluation results in the collection
-// have an associated error.
-func (rcr RebootCheckResults) HasErrors() bool {
-	for _, result := range rcr {
-		if result.Err != nil {
+// Evaluate performs an evaluation of each assertion in the collection to
+// determine whether a reboot is needed.
+func (rras RebootRequiredAsserters) Evaluate() {
+	for i := range rras {
+		rras[i].Evaluate()
+	}
+}
+
+// HasErrors indicates whether any of the assertion evaluations resulted in an
+// error. Missing optional items are excluded. A boolean value is accepted
+// which indicates whether assertion values marked as ignored (during
+// filtering) should also be considered. The caller is responsible for
+// filtering the collection prior to calling this method.
+func (rras RebootRequiredAsserters) HasErrors(evalIgnored bool) bool {
+	for _, assertion := range rras {
+		if assertion.Err() != nil {
 			// Don't report unsuccessful matches for optional items.
 			//
 			// TODO: Should we use this method to surface all errors and
 			// provide another method to filter out optional item match
 			// errors?
-			if errors.Is(result.Err, ErrMissingOptionalItem) {
+			if errors.Is(assertion.Err(), ErrMissingOptionalItem) {
+				continue
+			}
+
+			if assertion.Ignored() && !evalIgnored {
 				continue
 			}
 
@@ -136,19 +162,26 @@ func (rcr RebootCheckResults) HasErrors() bool {
 }
 
 // NumErrors indicates how many of the evaluation results in the collection
-// have an associated error.
-func (rcr RebootCheckResults) NumErrors() int {
+// have an associated error. Missing optional items are excluded. A boolean
+// value is accepted which indicates whether assertion values marked as
+// ignored (during filtering) should also be considered. The caller is
+// responsible for filtering the collection prior to calling this method.
+func (rras RebootRequiredAsserters) NumErrors(evalIgnored bool) int {
 	var counter int
 
-	for _, result := range rcr {
-		if result.Err != nil {
+	for _, assertion := range rras {
+		if assertion.Err() != nil {
 
 			// Don't report unsuccessful matches for optional items.
 			//
 			// TODO: Should we use this method to surface all errors and
 			// provide another method to filter out optional item match
 			// errors?
-			if errors.Is(result.Err, ErrMissingOptionalItem) {
+			if errors.Is(assertion.Err(), ErrMissingOptionalItem) {
+				continue
+			}
+
+			if assertion.Ignored() && !evalIgnored {
 				continue
 			}
 
@@ -157,27 +190,34 @@ func (rcr RebootCheckResults) NumErrors() int {
 	}
 
 	return counter
-
 }
 
 // Errs returns a slice of all errors associated with evaluation results in
-// the collection *EXCEPT* for unsuccessful optional assertions. An empty
-// slice is returned if there are no errors.
-func (rcr RebootCheckResults) Errs() []error {
-	errs := make([]error, 0, rcr.NumErrors())
-	for _, result := range rcr {
-		if result.Err != nil {
+// the collection. Missing optional items are excluded. A boolean value is
+// accepted which indicates whether assertion values marked as ignored (during
+// filtering) should also be considered.
+//
+// The caller is responsible for filtering the collection prior to calling
+// this method.
+func (rras RebootRequiredAsserters) Errs(evalIgnored bool) []error {
+	errs := make([]error, 0, rras.NumErrors(evalIgnored))
+	for _, assertion := range rras {
+		if assertion.Err() != nil {
 
 			// Don't report unsuccessful matches for optional items.
 			//
 			// TODO: Should we use this method to surface all errors and
 			// provide another method to filter out optional item match
 			// errors?
-			if errors.Is(result.Err, ErrMissingOptionalItem) {
+			if errors.Is(assertion.Err(), ErrMissingOptionalItem) {
 				continue
 			}
 
-			errs = append(errs, result.Err)
+			if assertion.Ignored() && !evalIgnored {
+				continue
+			}
+
+			errs = append(errs, assertion.Err())
 		}
 	}
 
@@ -186,9 +226,12 @@ func (rcr RebootCheckResults) Errs() []error {
 
 // RebootRequired indicates whether any of the evaluation results in the
 // collection indicate the need for a reboot.
-func (rcr RebootCheckResults) RebootRequired() bool {
-	for _, result := range rcr {
-		if result.RebootRequired {
+func (rras RebootRequiredAsserters) RebootRequired() bool {
+	for _, assertion := range rras {
+
+		// NOTE: We're relying on the assertion-specific logic to filter out
+		// any that have been marked as ignored.
+		if assertion.RebootRequired() {
 			return true
 		}
 	}
@@ -196,18 +239,18 @@ func (rcr RebootCheckResults) RebootRequired() bool {
 	return false
 }
 
-// RebootAssertionsApplied indicates how many reboot assertions were applied
-// to build the evaluation results collection.
-func (rcr RebootCheckResults) RebootAssertionsApplied() int {
-	return len(rcr)
+// NumApplied indicates how many reboot assertions were applied.
+func (rras RebootRequiredAsserters) NumApplied() int {
+	return len(rras)
 }
 
-// RebootAssertionsMatched indicates how many of the evaluation results in the
-// collection indicate the need for a reboot.
-func (rcr RebootCheckResults) RebootAssertionsMatched() int {
+// NumMatched indicates how many of the items in the collection indicate the
+// need for a reboot. The caller is responsible for filtering the collection
+// prior to calling this method.
+func (rras RebootRequiredAsserters) NumMatched() int {
 	var counter int
-	for _, result := range rcr {
-		if result.RebootRequired {
+	for _, assertion := range rras {
+		if assertion.RebootRequired() {
 			counter++
 		}
 	}
@@ -215,12 +258,13 @@ func (rcr RebootCheckResults) RebootAssertionsMatched() int {
 	return counter
 }
 
-// RebootAssertionsNotMatched indicates how many of the evaluation results in
-// the collection do not indicate the need for a reboot.
-func (rcr RebootCheckResults) RebootAssertionsNotMatched() int {
+// NumNotMatched indicates how many of the items in the collection do not
+// indicate the need for a reboot. The caller is responsible for filtering the
+// collection prior to calling this method.
+func (rras RebootRequiredAsserters) NumNotMatched() int {
 	var counter int
-	for _, result := range rcr {
-		if !result.RebootRequired {
+	for _, assertion := range rras {
+		if !assertion.RebootRequired() {
 			counter++
 		}
 	}
@@ -229,19 +273,20 @@ func (rcr RebootCheckResults) RebootAssertionsNotMatched() int {
 }
 
 // ServiceState returns the appropriate Service Check Status label and exit
-// code for the collection's evaluation results.
-func (rcr RebootCheckResults) ServiceState() nagios.ServiceState {
+// code for the collection's evaluation results. The caller is responsible for
+// filtering the collection prior to calling this method.
+func (rras RebootRequiredAsserters) ServiceState() nagios.ServiceState {
 	var stateLabel string
 	var stateExitCode int
 
 	switch {
-	case rcr.IsCriticalState():
+	case rras.HasCriticalState():
 		stateLabel = nagios.StateCRITICALLabel
 		stateExitCode = nagios.StateCRITICALExitCode
-	case rcr.IsWarningState():
+	case rras.HasWarningState():
 		stateLabel = nagios.StateWARNINGLabel
 		stateExitCode = nagios.StateWARNINGExitCode
-	case rcr.IsOKState():
+	case rras.IsOKState():
 		stateLabel = nagios.StateOKLabel
 		stateExitCode = nagios.StateOKExitCode
 	default:
@@ -255,35 +300,143 @@ func (rcr RebootCheckResults) ServiceState() nagios.ServiceState {
 	}
 }
 
-// IsCriticalState indicates whether any results in the collection have a
-// CRITICAL state.
-func (rcr RebootCheckResults) IsCriticalState() bool {
-	switch {
+// HasCriticalState indicates whether any items in the collection were
+// evaluated to a CRITICAL state. The caller is responsible for filtering the
+// collection prior to calling this method.
+func (rras RebootRequiredAsserters) HasCriticalState() bool {
+	for _, assertion := range rras {
+		if assertion.IsCriticalState() {
+			return true
+		}
+	}
 
-	// If we could determine that a reboot is required we consider that to be
-	// a WARNING state.
-	case rcr.RebootRequired():
-		return false
+	return false
+}
 
-	// If we were unable to determine whether a reboot is required due to
-	// errors we consider that to be a CRITICAL state.
-	case rcr.HasErrors():
-		return true
+// HasWarningState indicates whether any items in the collection were
+// evaluated to a WARNING state. The caller is responsible for filtering the
+// collection prior to calling this method.
+func (rras RebootRequiredAsserters) HasWarningState() bool {
+	for _, assertion := range rras {
+		if assertion.IsWarningState() {
+			return true
+		}
+	}
 
-	// No reboot required and no errors, not CRITICAL state.
-	default:
-		return false
+	return false
+}
 
+// IsOKState indicates whether all items in the collection were evaluated to
+// an OK state. The caller is responsible for filtering the collection prior
+// to calling this method.
+func (rras RebootRequiredAsserters) IsOKState() bool {
+	for _, assertion := range rras {
+		if !assertion.IsOKState() {
+			logger.Printf("%q failed IsOKState() check", assertion.String())
+			return false
+		}
+	}
+
+	return true
+}
+
+// HasRebootRequired indicates whether the collection contains an entry whose
+// evaluation indicates that a reboot is needed. Entries marked as ignored are
+// not considered. The caller is responsible for filtering the collection
+// prior to calling this method.
+func (rras RebootRequiredAsserters) HasRebootRequired() bool {
+	for _, assertion := range rras {
+		if assertion.RebootRequired() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// HasIgnored indicates whether the collection contains an entry marked as
+// ignored. The caller is responsible for filtering the collection prior to
+// calling this method.
+func (rras RebootRequiredAsserters) HasIgnored() bool {
+	for _, assertion := range rras {
+		if assertion.Ignored() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Filter uses the list of specified ignore patterns to mark any applicable
+// items in the collection as ignored. Filter should be called before
+// performing final state evaluation.
+func (rras RebootRequiredAsserters) Filter(ignorePatterns []string) {
+	for i := range rras {
+		rras[i].Filter(ignorePatterns)
 	}
 }
 
-// IsWarningState indicates whether any results in the collection have a
-// WARNING state.
-func (rcr RebootCheckResults) IsWarningState() bool {
-	return rcr.RebootRequired()
+// NumIgnored indicates how many of the items in the collection have been
+// marked as ignored. The caller is responsible for filtering the collection
+// prior to calling this method.
+func (rras RebootRequiredAsserters) NumIgnored() int {
+	var counter int
+	for _, assertion := range rras {
+		if assertion.Ignored() {
+			logger.Printf("%q MARKED AS IGNORED", assertion)
+			counter++
+		}
+	}
+
+	return counter
 }
 
-// IsOKState indicates whether all results in the collection have an OK state.
-func (rcr RebootCheckResults) IsOKState() bool {
-	return !rcr.RebootRequired() && !rcr.HasErrors()
+// NumNotIgnored indicates how many of the items in the collection have not
+// been marked as ignored. The caller is responsible for filtering the
+// collection prior to calling this method.
+func (rras RebootRequiredAsserters) NumNotIgnored() int {
+	var counter int
+	for _, assertion := range rras {
+		if !assertion.Ignored() {
+			counter++
+		}
+	}
+
+	return counter
+}
+
+// NotIgnoredItems returns all items in the collection that have not been
+// marked as ignored. If all items have been marked as ignored an empty
+// collection is returned. The caller is responsible for filtering the
+// collection prior to calling this method.
+func (rras RebootRequiredAsserters) NotIgnoredItems() RebootRequiredAsserters {
+	logger.Printf("%d items not marked as ignored", rras.NumNotIgnored())
+
+	assertions := make(RebootRequiredAsserters, 0, rras.NumNotIgnored())
+	for _, assertion := range rras {
+		if !assertion.Ignored() {
+			assertions = append(assertions, assertion)
+		}
+	}
+
+	return assertions
+}
+
+// IgnoredItems returns all items in the collection that have been marked as
+// ignored. If no items have been marked as ignored an empty collection is
+// returned. The caller is responsible for filtering the collection prior to
+// calling this method.
+func (rras RebootRequiredAsserters) IgnoredItems() RebootRequiredAsserters {
+	logger.Printf("%d items marked as ignored", rras.NumIgnored())
+
+	assertions := make(RebootRequiredAsserters, 0, rras.NumIgnored())
+	for _, assertion := range rras {
+		if assertion.Ignored() {
+			assertions = append(assertions, assertion)
+		}
+	}
+
+	logger.Printf("Returning %d items marked as ignored", len(assertions))
+
+	return assertions
 }


### PR DESCRIPTION
## OVERVIEW

To work around an apparent false-positive "needs a reboot" match for a specific registry key, initial support has been provided for ignoring assertion path matches.

This initial support uses a hard-coded default list (of one entry at present), but changes included in this commit should make it possible to (relatively) easily provide support for user-specified paths to ignore.

## CHANGES

Many, many changes have been applied both to provide support for ignoring assertion path matches and to support further "runtime" detail tracking. I'm not particularly a fan of the final state of the changes and am considering further refactoring once the dust settles.

A few cherry-picked changes worth highlighting:

- add initial support for ignoring specified assertion path matches
  - a default list (empty for files, 1 entry for registry keys) is provided with plans to continue growing it over time with additional false-positive (or low value) paths
- add new `--show-ignored` flag to enable listing assertion matches that are marked as ignored
- lots of additional debug logging
- add `ignored_assertions` performance data metric
- rework implementation of assertions (internal changes)
  - now tracked exclusively as pointers instead of mostly static values
  - previously the `Key` type's `handle` field was the only "runtime" level value tracked
  - add new `runtime` field for assertions to track transient details such as registry key handle, paths matched, found/discovered "needs reboot" evidence, etc.
- minor refactoring of the final plugin results report
- README examples refresh

## References

- fixes GH-32