### PR TITLE
Fix incorrect short flag for show ignored option

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -37,7 +37,7 @@ const (
 	TimeoutFlagLong      string = "timeout"
 	TimeoutFlagShort     string = "t"
 	ShowIgnoredFlagLong  string = "show-ignored"
-	ShowIgnoredFlagShort string = "li"
+	ShowIgnoredFlagShort string = "si"
 	LogLevelFlagLong     string = "log-level"
 	LogLevelFlagShort    string = "ll"
 )


### PR DESCRIPTION
I was originally intending to name the flag `list-ignored` and changed my mind at the last minute. I missed updating this entry to reflect that change of direction.

refs GH-32
refs GH-46