### PR TITLE
Explicitly disable colorized plugin logger output

### DIFF
--- a/cmd/check_reboot/main.go
+++ b/cmd/check_reboot/main.go
@@ -49,7 +49,7 @@ func main() {
 
 		// We make some assumptions when setting up our logger as we do not
 		// have a working configuration based on sysadmin-specified choices.
-		consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr}
+		consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true}
 		logger := zerolog.New(consoleWriter).With().Timestamp().Caller().Logger()
 
 		logger.Err(cfgErr).Msg("Error initializing application")

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -99,7 +99,7 @@ func (c *Config) setupLogging(appType AppType) error {
 		// Plugin logging uses ConsoleWriter to generate human-friendly,
 		// colorized output to stderr. Log output is sent to stderr to prevent
 		// mixing in with stdout output intended for the Nagios console.
-		consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr}
+		consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true}
 		c.Log = zerolog.New(consoleWriter).With().Timestamp().Caller().
 			Str("version", Version()).
 			Str("logging_level", c.LoggingLevel).


### PR DESCRIPTION
Leaving it enabled can lead to embedded formatting codes in emitted log messages (which could end up directly in log files).