### PR TITLE
Fix mispelling of Inspector app type

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,12 +37,12 @@ type AppType struct {
 	// Plugin represents an application used as a Nagios plugin.
 	Plugin bool
 
-	// Inspecter represents an application used for one-off or isolated
+	// Inspector represents an application used for one-off or isolated
 	// checks. Unlike a Nagios plugin which is focused on specific attributes
-	// resulting in a severity-based outcome, an Inspecter application is
+	// resulting in a severity-based outcome, an Inspector application is
 	// intended for examining a small set of targets for
 	// informational/troubleshooting purposes.
-	Inspecter bool
+	Inspector bool
 }
 
 // Config represents the application configuration as specified via

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -57,5 +57,5 @@ const (
 
 const (
 	appTypePlugin    string = "plugin"
-	appTypeInspecter string = "inspecter"
+	appTypeInspector string = "inspector"
 )

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -69,7 +69,7 @@ func (c *Config) handleFlagsConfig(appType AppType) {
 		flag.BoolVar(&c.DisableDefaultIgnored, DisableDefaultIgnoredFlagShort, defaultDisableDefaultIgnored, disableDefaultIgnoredFlagHelp+" (shorthand)")
 		flag.BoolVar(&c.DisableDefaultIgnored, DisableDefaultIgnoredFlagLong, defaultDisableDefaultIgnored, disableDefaultIgnoredFlagHelp)
 
-	case appType.Inspecter:
+	case appType.Inspector:
 
 		// Override the default Help output with a brief lead-in summary of
 		// the expected syntax and project version.

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -85,14 +85,14 @@ func (c *Config) setupLogging(appType AppType) error {
 	// troubleshooting. We can extend the logged fields as needed by each CLI
 	// application or Nagios plugin to cover unique details.
 	switch {
-	case appType.Inspecter:
+	case appType.Inspector:
 		// CLI app logging uses ConsoleWriter to generate human-friendly,
 		// colorized output to stdout.
 		consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout}
 		c.Log = zerolog.New(consoleWriter).With().Timestamp().Caller().
 			Str("version", Version()).
 			Str("logging_level", c.LoggingLevel).
-			Str("app_type", appTypeInspecter).
+			Str("app_type", appTypeInspector).
 			Logger()
 
 	case appType.Plugin:

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -18,7 +18,7 @@ import (
 func (c Config) validate(appType AppType) error {
 
 	switch {
-	case appType.Inspecter:
+	case appType.Inspector:
 
 	case appType.Plugin:
 


### PR DESCRIPTION
Replace `inspecter` with `inspector`.

I suspect that I was at least partially thinking of the Go idiom of naming interfaces with an `er` suffix when I came up with the app type.

refs atc0005/todo#49