### PR TITLE
Drop explicit plugin runtime tracking

### DIFF
--- a/cmd/check_reboot/main.go
+++ b/cmd/check_reboot/main.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/atc0005/check-restart/internal/config"
 	"github.com/atc0005/check-restart/internal/restart"
@@ -24,15 +23,8 @@ import (
 )
 
 func main() {
-	// Start the timer. We'll use this to emit the plugin runtime as a
-	// performance data metric.
-	pluginStart := time.Now()
 
-	// Set initial "state" as valid, adjust as we go.
-	var nagiosExitState = nagios.ExitState{
-		LastError:      nil,
-		ExitStatusCode: nagios.StateOKExitCode,
-	}
+	nagiosExitState := nagios.New()
 
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
@@ -63,9 +55,6 @@ func main() {
 
 		return
 	}
-
-	// Collect last minute details just before ending plugin execution.
-	defer appendPerfData(&nagiosExitState, pluginStart, cfg.Log)
 
 	if cfg.EmitBranding {
 		// If enabled, show application details at end of notification

--- a/cmd/check_reboot/main_test.go
+++ b/cmd/check_reboot/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/atc0005/go-nagios"
+)
+
+// TestEmptyClientPerfDataAndConstructedExitStateProducesDefaultTimeMetric
+// asserts that omitted performance data from client code produces a default
+// time metric when using the ExitState constructor.
+func TestEmptyClientPerfDataAndConstructedExitStateProducesDefaultTimeMetric(t *testing.T) {
+	t.Parallel()
+
+	// Setup ExitState type the same way that client code using the
+	// constructor would.
+	nagiosExitState := nagios.New()
+
+	// Performance Data metrics are not emitted if we do not supply a
+	// ServiceOutput value.
+	nagiosExitState.ServiceOutput = "TacoTuesday"
+
+	var outputBuffer strings.Builder
+
+	nagiosExitState.SetOutputTarget(&outputBuffer)
+
+	// os.Exit calls break tests
+	nagiosExitState.SkipOSExit()
+
+	// Process exit state, emit output to our output buffer.
+	nagiosExitState.ReturnCheckResults()
+
+	want := fmt.Sprintf(
+		"%s | %s",
+		nagiosExitState.ServiceOutput,
+		"'time'=",
+	)
+
+	got := outputBuffer.String()
+
+	if !strings.Contains(got, want) {
+		t.Errorf("ERROR: Plugin output does not contain the expected time metric")
+		t.Errorf("\nwant %q\ngot %q", want, got)
+	} else {
+		t.Logf("OK: Emitted performance data contains the expected time metric.")
+	}
+}

--- a/cmd/check_reboot/perfdata.go
+++ b/cmd/check_reboot/perfdata.go
@@ -9,27 +9,10 @@ package main
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/atc0005/check-restart/internal/restart"
 	"github.com/atc0005/go-nagios"
-	"github.com/rs/zerolog"
 )
-
-func appendPerfData(exitState *nagios.ExitState, start time.Time, logger zerolog.Logger) {
-	// Record plugin runtime, emit this metric regardless of exit
-	// point/cause.
-	runtimeMetric := nagios.PerformanceData{
-		Label: "time",
-		Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
-	}
-	if err := exitState.AddPerfData(false, runtimeMetric); err != nil {
-		logger.Error().
-			Err(err).
-			Msg("failed to add time (runtime) performance data metric")
-	}
-
-}
 
 // getPerfData gathers performance data metrics that we wish to report.
 func getPerfData(


### PR DESCRIPTION
- Allow the new nagios package functionality to handle tracking and emitting the `time` metric automatically at plugin
completion.
- Add test from the atc0005/go-nagios project to assert that the inherited/automatic `time` metric provided by the nagios package is emitted at plugin completion.
  - Since this plugin is no longer explicitly tracking this performance data metric this test helps ensure that the nagios package continues to provide it.