### PR TITLE
Add missing "clean" step to recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,6 +332,6 @@ links: windows-x86-links windows-x64-links linux-x86-links linux-x64-links
 
 .PHONY: release-build
 ## release-build: generates assets for public release
-release-build: windows-x64 windows-x64-links
+release-build: clean windows-x64 windows-x64-links
 
 	@echo "Completed all tasks for release build"


### PR DESCRIPTION
Call clean before performing primary release-build steps.