### PR TITLE
Replace backslashes in report output with slashes

### DIFF
--- a/internal/restart/reports/reports.go
+++ b/internal/restart/reports/reports.go
@@ -123,6 +123,13 @@ func writeAssertions(w io.Writer, assertions restart.RebootRequiredAsserters, ve
 		// While there is *usually* one reason for a reboot, the current
 		// design allows for multiple reasons.
 		for _, reason := range assertion.RebootReasons() {
+			// Prevent Nagios (or email clients rendering notifications) from
+			// dropping path separators by replacing Windows-specific registry
+			// and file path separators (even the escaped backslash) with a
+			// single slash.
+			reason = strings.ReplaceAll(reason, `\\`, `\`)
+			reason = strings.ReplaceAll(reason, `\`, `/`)
+
 			fmt.Fprintf(w, topDetailTemplateStr, reason, nagios.CheckOutputEOL)
 
 			// We are processing types beneath RebootReasons so that we can


### PR DESCRIPTION
Attempt to work around either Nagios or email clients from dropping path separators in notifications.

fixes GH-89