### PR TITLE
Use UNKNOWN state for perfdata add failure

### DIFF
--- a/cmd/check_reboot/main.go
+++ b/cmd/check_reboot/main.go
@@ -111,6 +111,17 @@ func main() {
 		log.Error().
 			Err(err).
 			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
 	}
 
 	switch {


### PR DESCRIPTION
Abort with UNKNOWN state when failing to add/gather generated performance data.

refs GH-93