### PR TITLE
Use UNKNOWN state for failure to validate assertions

### DIFF
--- a/cmd/check_reboot/main.go
+++ b/cmd/check_reboot/main.go
@@ -92,10 +92,10 @@ func main() {
 		log.Error().Err(err).Msg("Failed to validate provided assertions")
 
 		plugin.AddError(err)
-		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
 		plugin.ServiceOutput = fmt.Sprintf(
 			"%s: Failed to validate list of reboot evaluations",
-			nagios.StateCRITICALLabel,
+			nagios.StateUNKNOWNLabel,
 		)
 
 		return


### PR DESCRIPTION
Assertions (file, registry) are currently hard-coded values within the plugin source code. Because any errors in their content is the fault of the plugin, we use an UNKNOWN state instead of a WARNING or CRITICAL state (because the problem is internal instead of external against the monitored "reboot needed" values).

fixes GH-93