### PR TITLE
Drop Summary section from output

### DIFF
--- a/internal/restart/reports/reports.go
+++ b/internal/restart/reports/reports.go
@@ -68,6 +68,8 @@ func CheckRebootOneLineSummary(assertions restart.RebootRequiredAsserters, evalI
 
 }
 
+//nolint:all
+//lint:ignore U1000 disabling use per GH-119, but may re-enable later via flag
 func writeReportHeader(w io.Writer, assertions restart.RebootRequiredAsserters, verbose bool) {
 	fmt.Fprintf(
 		w,
@@ -144,7 +146,9 @@ func writeAssertions(w io.Writer, assertions restart.RebootRequiredAsserters, ve
 func CheckRebootReport(assertions restart.RebootRequiredAsserters, showIgnored bool, verbose bool) string {
 	var report strings.Builder
 
-	writeReportHeader(&report, assertions, verbose)
+	// Disabling per GH-119, but may re-enable later via flag.
+	//
+	// writeReportHeader(&report, assertions, verbose)
 
 	switch {
 


### PR DESCRIPTION
The goal is to aggressively trim duplicated details from output in order to make room for unique "reboot required" evidence details and the Summary section duplicates details already available in the one-line summary or lead-in text.

Leaving the `writeReportHeader` helper function intact for now with a `nolint` entry noting the applicable GH issue for later consideration. 

Perhaps we'll add a flag later to restore the output if we expand its purpose (e.g., if we list the number of registry matches alongside the number of file/directory matches).

fixes GH-119