### PR TITLE
Temporarily disable problematic assertions

### DIFF
--- a/internal/restart/registry/assertions_windows.go
+++ b/internal/restart/registry/assertions_windows.go
@@ -52,45 +52,55 @@ func DefaultRebootRequiredAssertions() restart.RebootRequiredAsserters {
 			},
 			expectedData: 0,
 		},
-		&KeyStrings{
-			Key: Key{
-				root:  registry.LOCAL_MACHINE,
-				path:  `SYSTEM\CurrentControlSet\Control\Session Manager`,
-				value: "PendingFileRenameOperations",
-				evidenceExpected: KeyRebootEvidence{
-					// FIXME: Based on recent experience, this is a VERY noisy
-					// evidence marker. Just having the value present has not
-					// proven sufficient to indicate the need for a reboot.
-					ValueExists: true,
+		/*
+
+			Disabling use of these assertions until fine-grained control is
+			available to exclude known problematic entries.
+
+			See also:
+
+			- https://github.com/atc0005/check-restart/issues/133
+
+			&KeyStrings{
+				Key: Key{
+					root:  registry.LOCAL_MACHINE,
+					path:  `SYSTEM\CurrentControlSet\Control\Session Manager`,
+					value: "PendingFileRenameOperations",
+					evidenceExpected: KeyRebootEvidence{
+						// FIXME: Based on recent experience, this is a VERY noisy
+						// evidence marker. Just having the value present has not
+						// proven sufficient to indicate the need for a reboot.
+						ValueExists: true,
+					},
+				},
+
+				// TODO: this is the default and not really needed. Adding this
+				// just for the time being as a reminder that the support is
+				// available.
+				additionalEvidence: KeyStringsRebootEvidence{
+					ValueFound:     false,
+					AllValuesFound: false,
 				},
 			},
+			&KeyStrings{
+				Key: Key{
+					root:  registry.LOCAL_MACHINE,
+					path:  `SYSTEM\CurrentControlSet\Control\Session Manager`,
+					value: "PendingFileRenameOperations2",
+					evidenceExpected: KeyRebootEvidence{
+						ValueExists: true,
+					},
+				},
 
-			// TODO: this is the default and not really needed. Adding this
-			// just for the time being as a reminder that the support is
-			// available.
-			additionalEvidence: KeyStringsRebootEvidence{
-				ValueFound:     false,
-				AllValuesFound: false,
-			},
-		},
-		&KeyStrings{
-			Key: Key{
-				root:  registry.LOCAL_MACHINE,
-				path:  `SYSTEM\CurrentControlSet\Control\Session Manager`,
-				value: "PendingFileRenameOperations2",
-				evidenceExpected: KeyRebootEvidence{
-					ValueExists: true,
+				// TODO: this is the default and not really needed. Adding this
+				// just for the time being as a reminder that the support is
+				// available.
+				additionalEvidence: KeyStringsRebootEvidence{
+					ValueFound:     false,
+					AllValuesFound: false,
 				},
 			},
-
-			// TODO: this is the default and not really needed. Adding this
-			// just for the time being as a reminder that the support is
-			// available.
-			additionalEvidence: KeyStringsRebootEvidence{
-				ValueFound:     false,
-				AllValuesFound: false,
-			},
-		},
+		*/
 		&Key{
 			root: registry.LOCAL_MACHINE,
 


### PR DESCRIPTION
Disable assertions for registry key values:

- `PendingFileRenameOperations`
- `PendingFileRenameOperations2`

in path:

- `SYSTEM\CurrentControlSet\Control\Session Manager`

in order to mute problematic results.

This is a workaround until support is available to filter out specific entries from the collection of `MULTI_SZ` entries found in those registry key values (e.g., printer drivers, Firefox, Chrome).

refs GH-133