### PR TITLE
Correct logging format listed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ restart (service) or reboot (system) is needed.
     the service check result
 
 - Optional, leveled logging using `rs/zerolog` package
-  - JSON-format output (to `stderr`)
+  - [`logfmt`][logfmt] format output (to `stderr`)
   - choice of `disabled`, `panic`, `fatal`, `error`, `warn`, `info` (the
     default), `debug` or `trace`.
 
@@ -452,3 +452,5 @@ See the [LICENSE](LICENSE) file for details.
 [go-supported-releases]: <https://go.dev/doc/devel/release#policy> "Go Release Policy"
 
 [nsclient-external-scripts]: <https://docs.nsclient.org/howto/external_scripts/> "NSClient++ External scripts"
+
+[logfmt]: <https://brandur.org/logfmt>


### PR DESCRIPTION
The logging output format was previously listed as `JSON`. Update this to correctly indicate that this project currently uses the `logfmt` format instead.

refs atc0005/todo#64
refs https://brandur.org/logfmt