### PR TITLE
Update build tags syntax

### DIFF
--- a/internal/restart/files/assertions_unix.go
+++ b/internal/restart/files/assertions_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Copyright 2022 Adam Chalkley
 //

--- a/internal/restart/files/assertions_windows.go
+++ b/internal/restart/files/assertions_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Copyright 2022 Adam Chalkley
 //

--- a/internal/restart/files/files_unix.go
+++ b/internal/restart/files/files_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Copyright 2022 Adam Chalkley
 //

--- a/internal/restart/files/files_windows.go
+++ b/internal/restart/files/files_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Copyright 2022 Adam Chalkley
 //

--- a/internal/restart/registry/assertions_unix.go
+++ b/internal/restart/registry/assertions_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Copyright 2022 Adam Chalkley
 //

--- a/internal/restart/registry/assertions_windows.go
+++ b/internal/restart/registry/assertions_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Copyright 2022 Adam Chalkley
 //

--- a/internal/restart/registry/registry_unix.go
+++ b/internal/restart/registry/registry_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Copyright 2022 Adam Chalkley
 //

--- a/internal/restart/registry/registry_windows.go
+++ b/internal/restart/registry/registry_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Copyright 2022 Adam Chalkley
 //


### PR DESCRIPTION
Drop older build tags as we're updating the minimum Go version in this project's go.mod file (soon).